### PR TITLE
don't strip [tag] blocks from subject (except for [PATCH])

### DIFF
--- a/tg-export.sh
+++ b/tg-export.sh
@@ -125,7 +125,7 @@ create_tg_commit()
 
 	# Get commit message and authorship information
 	git cat-file blob "$name:.topmsg" 2>/dev/null |
-	git mailinfo "$playground/^msg" /dev/null > "$playground/^info"
+	git mailinfo -b "$playground/^msg" /dev/null > "$playground/^info"
 
 	unset GIT_AUTHOR_NAME
 	unset GIT_AUTHOR_EMAIL


### PR DESCRIPTION
Many repositories use "[Tag]" blocks in their commit messages as a convention - ie:

https://github.com/PixarAnimationStudios/USD/commit/34075ef30efc9aa94a0c1e05c6e2d6f56d2a4853

The current version of topgit automatically strips out ALL such blocks - this scommit changes it so that it only strips out "[Patch]".