### PR TITLE
fix for tg-update when out-of-date with respect to remote

### DIFF
--- a/tg-update.sh
+++ b/tg-update.sh
@@ -925,6 +925,7 @@ update_branch_internal() {
 	if [ -s "$_depcheck" ]; then
 		<"$_depcheck" \
 			sed 's/ [^ ]* *$//' | # last is $_update_name
+			sed 's/\(^\| \):\([^ ]*\)/\1\2/g' | # strip ':' prefix
 			sed 's/.* \([^ ]*\)$/+\1/' | # only immediate dependencies
 			sed 's/^\([^+]\)/-\1/' | # now each line is +branch or -branch (+ == recurse)
 			>"$_depcheck.ideps" \


### PR DESCRIPTION
was getting errors that looked like this:
tg: Updating tg/branch base with deps: :refs/remotes/tgremote/top-bases/tg/branch tg/dep_branch
fatal: Not a valid object name refs/heads/:refs/remotes/tgremote/top-bases/tg/branch

Signed-off-by: Paul Molodowitch <pm@stanfordalumni.org>