### PR TITLE
tg-completion: fix extraction of available commands from output of help

### DIFF
--- a/contrib/tg-completion.bash
+++ b/contrib/tg-completion.bash
@@ -203,7 +203,7 @@ __tg_commands ()
 		return
 	fi
 	local i IFS=" "$'\n'
-	for i in $(tg help | sed -n 's/^Usage:.*(\([^)]*\)).*/\1/p' | tr '|' ' ')
+	for i in $(tg help | sed -e '1,/^Available tg commands.*/d' -e 's,\[\|\],,g')
 	do
 		case $i in
 		*--*)             : helper pattern;;


### PR DESCRIPTION
The completion script extracts the list of available tg commands from the output of the help command. This wasn't working (presumably because the output of 'tg help' has changed) and gets fixed by this commit.