### PR TITLE
tg--merging: manually update `MERGE_HEAD` (fix support with Git >=v2.46)

### DIFF
--- a/tg--merging.sh
+++ b/tg--merging.sh
@@ -137,7 +137,7 @@ git_topmerge()
 			printf '%s\n\n# Conflicts:\n' "$_msg"
 			sed -n "/$tab/s/^[^$tab]*/#/p" <"$tmpstdout" | sort -u
 		} >"$git_dir/MERGE_MSG"
-		git update-ref MERGE_HEAD "$_theirs" || :
+		printf '%s\n' "$_theirs" >"$git_dir/MERGE_HEAD" || :
 		echo 'Automatic merge failed; fix conflicts and then commit the result.'
 		rm -f "$tmpstdout"
 		return $_ret
@@ -145,7 +145,7 @@ git_topmerge()
 	if [ -n "$_ncmode" ]; then
 		# merge succeeded, but --no-commit requested, enter "merge" mode and return
 		printf '%s\n' "$_msg" >"$git_dir/MERGE_MSG"
-		git update-ref MERGE_HEAD "$_theirs" || :
+		printf '%s\n' "$_theirs" >"$git_dir/MERGE_HEAD" || :
 		echo 'Automatic merge went well; stopped before committing as requested.'
 		rm -f "$tmpstdout"
 		return $_ret


### PR DESCRIPTION
First, thank you for this great tool!

Since Git v2.46.0 and the commit [993d57eded](https://github.com/git/git/commit/993d57eded) ("`refs: pseudorefs are no refs`"), it is no longer allowed to use `git update-ref MERGE_HEAD`.

Because of this, TopGit was printing this message in case of merge conflicts:

    Auto-merging foo/bar
    CONFLICT (content): Merge conflict in foo/bar
    fatal: update_ref failed for ref 'MERGE_HEAD': refusing to update pseudoref 'MERGE_HEAD'
    Automatic merge failed; fix conflicts and then commit the result.

But resolving the conflicts had no effects: a `tg update --continue` command would go back to the same conflict over and over, because a simple commit was created instead of a merge one, linked the topic with its base after the merge resolution.

A simple workaround is to directly write the reference in the `.git/MERGE_HEAD` file. This way, it should work with previous and recent Git versions.